### PR TITLE
fixed error with endless checkStatus if process error, inform user 

### DIFF
--- a/src/homepage/HomePageMenu.jsx
+++ b/src/homepage/HomePageMenu.jsx
@@ -10,6 +10,7 @@ const HomePageMenu = function () {
   );
 
   const [isGenerating, setIsGenerating] = useState(false);
+  const [generationError, setGenerationError] = useState();
 
   function showIntro() {
     // enable to reset cookie when intro is explicitly opened (for debugging)
@@ -23,7 +24,7 @@ const HomePageMenu = function () {
   }
 
   function startGeneration(repo) {
-    generateMap(repo, setIsGenerating);
+    generateMap(repo, setIsGenerating, setGenerationError);
   }
 
   return isGenerating ? (
@@ -35,7 +36,10 @@ const HomePageMenu = function () {
       {intro ? (
         <Intro onClose={hideIntro} />
       ) : (
-        <RepoInputForm callback={startGeneration} />
+        <RepoInputForm
+          callback={startGeneration}
+          initialError={generationError}
+        />
       )}
 
       <footer>

--- a/src/homepage/RepoInputForm.jsx
+++ b/src/homepage/RepoInputForm.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
-import { func } from "prop-types";
+import { func, string } from "prop-types";
 
 import repoURLValidator from "./repoURLValidator";
 
-function RepoInputForm({ callback }) {
+function RepoInputForm({ callback, initialError }) {
   const [valid, setValid] = useState(false);
   const [error, setError] = useState();
   const [url, setUrl] = useState("");
@@ -41,8 +41,11 @@ function RepoInputForm({ callback }) {
         required
         placeholder="https://github.com/your/repo"
       />
-      <div id="error" style={{ visibility: valid ? "hidden" : "visible" }}>
-        {error}
+      <div
+        id="error"
+        style={{ visibility: valid && !initialError ? "hidden" : "visible" }}
+      >
+        {error || initialError}
       </div>
       <input
         type="image"
@@ -56,6 +59,7 @@ function RepoInputForm({ callback }) {
 
 RepoInputForm.propTypes = {
   callback: func.isRequired,
+  initialError: string,
 };
 
 export default RepoInputForm;


### PR DESCRIPTION
close  #12
prevent endless checkStatus in case of processing error (i.e. clone or log timeout)
inform user that we have processing error